### PR TITLE
Adapt build scan publication message parsing

### DIFF
--- a/app/src/main/kotlin/org/gradle/tools/trace/app/TraceToChromeTraceConverter.kt
+++ b/app/src/main/kotlin/org/gradle/tools/trace/app/TraceToChromeTraceConverter.kt
@@ -169,7 +169,7 @@ class TraceToChromeTraceConverter(val outputFile: File) : BuildOperationConverte
                 ?: return
 
             val text = spans["text"] ?: return
-            if (text.startsWith("Publishing build scan...")) {
+            if (text.startsWith("Publishing build scan...") || text.startsWith("Publishing Build Scan...")) {
                 expectBuildScanLinkProgressEvent = true
             } else if (expectBuildScanLinkProgressEvent) {
                 expectBuildScanLinkProgressEvent = false


### PR DESCRIPTION
Latest Develocity Gradle plugin outputs a slightly different Build Scan publication message, this PR checks for both messages.