### PR TITLE
Adapt to future Build Scan publication message

### DIFF
--- a/app/src/main/kotlin/org/gradle/tools/trace/app/TraceToChromeTraceConverter.kt
+++ b/app/src/main/kotlin/org/gradle/tools/trace/app/TraceToChromeTraceConverter.kt
@@ -169,7 +169,7 @@ class TraceToChromeTraceConverter(val outputFile: File) : BuildOperationConverte
                 ?: return
 
             val text = spans["text"] ?: return
-            if (text.startsWith("Publishing build scan...") || text.startsWith("Publishing Build Scan...")) {
+            if (text.startsWith("Publishing build scan...") || text.startsWith("Publishing Build Scan...") || text.startsWith("Publishing Build Scan to Develocity...")) {
                 expectBuildScanLinkProgressEvent = true
             } else if (expectBuildScanLinkProgressEvent) {
                 expectBuildScanLinkProgressEvent = false


### PR DESCRIPTION
Similar to https://github.com/gradle/gradle-trace-converter/pull/5, a new Build Scan publication message will be introduced in the next Develocity Gradle plugin.